### PR TITLE
refactoring & new options for login form

### DIFF
--- a/password-protected.php
+++ b/password-protected.php
@@ -322,12 +322,12 @@ class Password_Protected {
 
   			if ( isset( $_REQUEST['redirect_to'] ) ) {
   				$redirect_to = esc_url_raw( $_REQUEST['redirect_to'], array( 'http', 'https' ) );
-  				wp_redirect( $redirect_to );
+  				$this->safe_redirect( $redirect_to );
   				exit();
   			}
 
         $redirect_to = $this->get_login_page_url();
-  			wp_redirect( $redirect_to );
+  			$this->safe_redirect( $redirect_to );
   			exit();
   		}
 
@@ -393,7 +393,7 @@ class Password_Protected {
 
       $redirect_to = $this->get_login_page_url();
 
-			wp_redirect( $redirect_to );
+			$this->safe_redirect( $redirect_to );
 			exit();
 		}
 	}

--- a/password-protected.php
+++ b/password-protected.php
@@ -1,13 +1,13 @@
 <?php
 
 /*
-Plugin Name: Password Protected
+Plugin Name: Password Protected (MODIFIED)
 Plugin URI: https://wordpress.org/plugins/password-protected/
 Description: A very simple way to quickly password protect your WordPress site with a single password. Please note: This plugin does not restrict access to uploaded files and images and does not work on WP Engine or with some caching setups.
 Version: 1.9
 Author: Ben Huson
 Text Domain: password-protected
-Author URI: http://github.com/benhuson/password-protected/
+Author URI: https://github.com/Flip-Flop-Interactive/password-protected
 License: GPLv2
 */
 
@@ -170,7 +170,7 @@ class Password_Protected {
 		$query = array();
 
 		if (defined('PASSWORD_PROTECTED_PERMALINK')) {
-      $login_url = PASSWORD_PROTECTED_PERMALINK;
+      $login_url = ( is_ssl() ? 'https://' : 'http://' ) . $_SERVER['HTTP_HOST'] . PASSWORD_PROTECTED_PERMALINK;
 	  } else {
       $login_url = home_url();
       $query['password-protected'] = 'login';

--- a/password-protected.php
+++ b/password-protected.php
@@ -84,7 +84,7 @@ class Password_Protected {
   */
   function password_protected_rewrites_init() {
     add_rewrite_rule(
-      'login/$',
+      'login$',
       'index.php?password-protected=login',
       'top'
     );

--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 === Password Protected ===
-Contributors: husobj
+Contributors: husobj, klokie
 Tags: password, protect, password protect, login
 Requires at least: 3.5
 Tested up to: 4.1
@@ -17,6 +17,8 @@ This plugin only protects your WordPress content. It **does not protect and imag
 Features include:
 
 * Password protect your WordPress site with a single password.
+* Option to assign a permalink URI to the login form, rather than including a long query string.
+* Option to redirect after successful login.
 * Option to allow access to feeds.
 * Option to allow administrators access without entering password.
 * Works with Mark Jaquith's [Login Logo](http://wordpress.org/extend/plugins/login-logo/) plugin.

--- a/theme/password-protected-login.php
+++ b/theme/password-protected-login.php
@@ -7,6 +7,8 @@
 
 global $wp_version, $Password_Protected, $error, $is_iphone;
 
+$redirect_to = isset( $_REQUEST['redirect_to'] ) ? $_REQUEST['redirect_to'] : '';
+
 /**
  * WP Shake JS
  */
@@ -106,7 +108,7 @@ do_action( 'password_protected_login_head' );
 			<input type="submit" name="wp-submit" id="wp-submit" class="button button-primary button-large" value="<?php esc_attr_e( 'Log In', 'password-protected' ); ?>" tabindex="100" />
 			<input type="hidden" name="testcookie" value="1" />
 			<input type="hidden" name="password-protected" value="login" />
-			<input type="hidden" name="redirect_to" value="<?php echo esc_attr( $_REQUEST['redirect_to'] ); ?>" />
+			<input type="hidden" name="redirect_to" value="<?php echo $redirect_to; ?>" />
 		</p>
 	</form>
 


### PR DESCRIPTION
I've done a bit of refactoring. Now the login form can be assigned to a permalink (`/login` by default), and the post-login redirection can be disabled. Both of those options are defined in `password-protected.php`. Cheers!
p.s. you have to update your permalink rewrite rules by clicking "Save Changes" on the permalink settings page in the wp-admin.
