### PR TITLE
Added CAPTCHA using Advanced noCaptcha & invisible Captcha

### DIFF
--- a/admin/admin.php
+++ b/admin/admin.php
@@ -147,6 +147,16 @@ class Password_Protected_Admin {
 			'password_protected'
 		);
 
+		if (is_plugin_active('advanced-nocaptcha-recaptcha/advanced-nocaptcha-recaptcha.php')) {
+			add_settings_field(
+				'password_protected_captcha',
+				__('Enable <a href="options-general.php?page=anr-admin-settings">CAPTCHA</a>', 'password-protected'),
+				array($this, 'password_protected_captcha_field'),
+				$this->options_group,
+				'password_protected'
+			);
+		}
+
 		add_settings_field(
 			'password_protected_remember_me',
 			__( 'Allow Remember me', 'password-protected' ),
@@ -170,6 +180,7 @@ class Password_Protected_Admin {
 		register_setting( $this->options_group, 'password_protected_users', 'intval' );
 		register_setting( $this->options_group, 'password_protected_password', array( $this, 'sanitize_password_protected_password' ) );
 		register_setting( $this->options_group, 'password_protected_allowed_ip_addresses', array( $this, 'sanitize_ip_addresses' ) );
+		register_setting( $this->options_group, 'password_protected_captcha', 'boolval' );
 		register_setting( $this->options_group, 'password_protected_remember_me', 'boolval' );
 		register_setting( $this->options_group, 'password_protected_remember_me_lifetime', 'intval' );
 
@@ -290,6 +301,15 @@ class Password_Protected_Admin {
 			echo ' ' . esc_html( sprintf( __( 'Your IP is address %s.', 'password-protected' ), $_SERVER['REMOTE_ADDR'] ) );
 		}
 		echo '</p>';
+
+	}
+
+	/**
+	 * CAPTCHA Field
+	 */
+	public function password_protected_captcha_field() {
+
+		echo '<label><input name="password_protected_captcha" id="password_protected_captcha" type="checkbox" value="1" ' . checked( 1, get_option( 'password_protected_captcha' ), false ) . ' /></label>';
 
 	}
 

--- a/password-protected.php
+++ b/password-protected.php
@@ -359,6 +359,7 @@ class Password_Protected {
 					$this->clear_auth_cookie();
 					$this->errors->add('failed_captcha', __('Complete the CAPTCHA!', 'password-protected'));
 				}
+
 			}
 
 		}

--- a/password-protected.php
+++ b/password-protected.php
@@ -262,6 +262,23 @@ class Password_Protected {
 	}
 
 	/**
+	 * Check if the CAPTCHA is enabled
+	 * Will return false if advanced-nocaptcha-recaptcha is not active
+	 *
+	 * @return. boolean
+	 */
+	public function captcha_enabled() {
+
+		include_once(ABSPATH.'wp-admin/includes/plugin.php');
+		if (is_plugin_active('advanced-nocaptcha-recaptcha/advanced-nocaptcha-recaptcha.php')) {
+			return (bool)get_option('password_protected_captcha');
+		} else {
+			return false;
+		}
+
+	}
+
+	/**
 	 * Encrypt Password
 	 *
 	 * @param  string  $password  Password.
@@ -304,8 +321,11 @@ class Password_Protected {
 			$password_protected_pwd = $_REQUEST['password_protected_pwd'];
 			$pwd = get_option( 'password_protected_password' );
 
-			// If correct password...
-			if ( ( hash_equals( $pwd, $this->encrypt_password( $password_protected_pwd ) ) && $pwd != '' ) || apply_filters( 'password_protected_process_login', false, $password_protected_pwd ) ) {
+			// If correct password and CAPTCHA (or CAPTCHA is disabled)
+			if (((hash_equals($pwd, $this->encrypt_password($password_protected_pwd)) &&
+						$pwd != '') ||
+					apply_filters('password_protected_process_login', false, $password_protected_pwd))
+				&& ($this->captcha_enabled() == false || anr_verify_captcha())) {
 
 				$remember = isset( $_REQUEST['password_protected_rememberme'] ) ? boolval( $_REQUEST['password_protected_rememberme'] ) : false;
 
@@ -327,10 +347,18 @@ class Password_Protected {
 
 			} else {
 
-				// ... otherwise incorrect password
-				$this->clear_auth_cookie();
-				$this->errors->add( 'incorrect_password', __( 'Incorrect Password', 'password-protected' ) );
+				// Invalid password
+				if ($this->captcha_enabled() == false || anr_verify_captcha()) {
 
+					$this->clear_auth_cookie();
+					$this->errors->add('incorrect_password', __('Incorrect Password!', 'password-protected'));
+
+					// ... otherwise invalid CAPTCHA
+				} else {
+
+					$this->clear_auth_cookie();
+					$this->errors->add('failed_captcha', __('Complete the CAPTCHA!', 'password-protected'));
+				}
 			}
 
 		}

--- a/theme/password-protected-login.php
+++ b/theme/password-protected-login.php
@@ -121,7 +121,14 @@ do_action( 'password_protected_login_head' );
 			<input type="password" name="password_protected_pwd" id="password_protected_pass" class="input" value="" size="20" tabindex="20" /></label>
 		</p>
 
-		<?php if ( $Password_Protected->allow_remember_me() ) : ?>
+		<?php
+		if ($Password_Protected->captcha_enabled() == true) {
+			do_action('anr_captcha_form_field');
+			echo '<br>';
+		}
+		?>
+
+        <?php if ( $Password_Protected->allow_remember_me() ) : ?>
 			<p class="forgetmenot">
 				<label for="password_protected_rememberme"><input name="password_protected_rememberme" type="checkbox" id="password_protected_rememberme" value="1" tabindex="90" /> <?php esc_attr_e( 'Remember Me' ); ?></label>
 			</p>


### PR DESCRIPTION
This adds the option to implement a CAPTCHA using the [Advanced noCaptcha & invisible Captcha](https://wordpress.org/plugins/advanced-nocaptcha-recaptcha/) plugin. The option to use the CAPTCHA will only appear if that plugin is enabled.

Do let me know if there are any changes that you'd recommend I'd make.

![image](https://user-images.githubusercontent.com/16004217/94343920-81faad80-0013-11eb-8086-8883215abe6e.png)
